### PR TITLE
multiwriter-aws: fix clippy errors for redundant field names

### DIFF
--- a/src/writer_aws.rs
+++ b/src/writer_aws.rs
@@ -35,7 +35,7 @@ impl AWSLogsWriter {
         let client = aws_sdk_cloudwatchlogs::Client::new(&aws_config::defaults(BehaviorVersion::latest()).load().await);
         create_log_group(&client, &log_group_name).await;
         create_log_stream(&client, &log_group_name, &log_stream_name).await;
-        let writer = AWSLogsWriter { client:  client, log_group_name: log_group_name, log_stream_name: log_stream_name };
+        let writer = AWSLogsWriter { client, log_group_name, log_stream_name };
         Some(writer)
     }
 }


### PR DESCRIPTION
```
error: redundant field names in struct initialization
  --> src/writer_aws.rs:38:38
   |
38 |         let writer = AWSLogsWriter { client:  client, log_group_name: log_group_name, log_stream_name: log_stream_name };
   |                                      ^^^^^^^^^^^^^^^ help: replace it with: `client`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
   = note: `-D clippy::redundant-field-names` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::redundant_field_names)]`

error: redundant field names in struct initialization
  --> src/writer_aws.rs:38:55
   |
38 |         let writer = AWSLogsWriter { client:  client, log_group_name: log_group_name, log_stream_name: log_stream_name };
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `log_group_name`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

error: redundant field names in struct initialization
  --> src/writer_aws.rs:38:87
   |
38 |         let writer = AWSLogsWriter { client:  client, log_group_name: log_group_name, log_stream_name: log_stream_name };
   |                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `log_stream_name`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
```